### PR TITLE
Bugfix: text resized too small

### DIFF
--- a/AutoFitTextViewLibrary/src/com/example/autofittextviewtest/AutoResizeTextView.java
+++ b/AutoFitTextViewLibrary/src/com/example/autofittextviewtest/AutoResizeTextView.java
@@ -201,6 +201,8 @@ public class AutoResizeTextView extends TextView
     final int startSize=(int)_minTextSize;
     final int heightLimit=getMeasuredHeight()-getCompoundPaddingBottom()-getCompoundPaddingTop();
     _widthLimit=getMeasuredWidth()-getCompoundPaddingLeft()-getCompoundPaddingRight();
+    if (_widthLimit <= 0)
+      return;
     _availableSpaceRect.right=_widthLimit;
     _availableSpaceRect.bottom=heightLimit;
     super.setTextSize(TypedValue.COMPLEX_UNIT_PX,efficientTextSizeSearch(startSize,(int)_maxTextSize,_sizeTester,_availableSpaceRect));


### PR DESCRIPTION
Don't adjust textSize until getMeasureWidth() returns something larger than 0, otherwise, the textSize will be changed (to a value smaller than necessary), before being set to the correct value.
