### PR TITLE
check for textAllCaps

### DIFF
--- a/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
+++ b/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
@@ -104,6 +104,12 @@ public class AutoResizeTextView extends TextView {
     }
     
     @Override
+    public void  setAllCaps(boolean allCaps){
+        super.setAllCaps(allCaps);
+        _allCaps = allCaps;
+    }
+    
+    @Override
     public void setTypeface(final Typeface tf) {
         super.setTypeface(tf);
         adjustTextSize();

--- a/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
+++ b/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
@@ -28,7 +28,8 @@ public class AutoResizeTextView extends TextView {
     private int _widthLimit, _maxLines;
     private boolean _initialized = false;
     private TextPaint _paint;
-
+    private boolean _allCaps = false;
+    
     private interface SizeTester {
         /**
          * @param suggestedSize  Size of text to be tested
@@ -50,6 +51,9 @@ public class AutoResizeTextView extends TextView {
 
     public AutoResizeTextView(final Context context, final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
+
+        _allCaps = attrs.getAttributeBooleanValue("http://schemas.android.com/apk/res/android", "textAllCaps", false);
+        
         // using the minimal recommended font size
         _minTextSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 12, getResources().getDisplayMetrics());
         _maxTextSize = getTextSize();
@@ -93,6 +97,12 @@ public class AutoResizeTextView extends TextView {
         _initialized = true;
     }
 
+    @Override
+    public void setText(CharSequence text, BufferType type) {
+        if( _allCaps ) text = text.toString().toUpperCase();
+        super.setText(text, type);
+    }
+    
     @Override
     public void setTypeface(final Typeface tf) {
         super.setTypeface(tf);

--- a/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
+++ b/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
@@ -51,8 +51,6 @@ public class AutoResizeTextView extends TextView {
     public AutoResizeTextView(final Context context, final AttributeSet attrs, final int defStyle) {
         super(context, attrs, defStyle);
 
-        _allCaps = attrs.getAttributeBooleanValue("http://schemas.android.com/apk/res/android", "textAllCaps", false);
-        
         // using the minimal recommended font size
         _minTextSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 12, getResources().getDisplayMetrics());
         _maxTextSize = getTextSize();

--- a/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
+++ b/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
@@ -101,6 +101,12 @@ public class AutoResizeTextView extends TextView {
     }
 
     @Override
+    public void setAllCaps(boolean allCaps) {
+        super.setAllCaps(allCaps);
+        adjustTextSize();
+    }
+
+    @Override
     public void setTypeface(final Typeface tf) {
         super.setTypeface(tf);
         adjustTextSize();

--- a/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
+++ b/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.java
@@ -28,8 +28,7 @@ public class AutoResizeTextView extends TextView {
     private int _widthLimit, _maxLines;
     private boolean _initialized = false;
     private TextPaint _paint;
-    private boolean _allCaps = false;
-    
+
     private interface SizeTester {
         /**
          * @param suggestedSize  Size of text to be tested
@@ -69,7 +68,13 @@ public class AutoResizeTextView extends TextView {
             @Override
             public int onTestSize(final int suggestedSize, final RectF availableSPace) {
                 _paint.setTextSize(suggestedSize);
-                final String text = getText().toString();
+                final TransformationMethod transformationMethod = getTransformationMethod();
+                final String text;
+                if (transformationMethod != null)
+                        text = transformationMethod.getTransformation(getText(), AutoResizeTextView.this).toString();
+                    else 
+                        text = getText().toString();
+                        
                 final boolean singleLine = getMaxLines() == 1;
                 if (singleLine) {
                     textRect.bottom = _paint.getFontSpacing();
@@ -97,18 +102,6 @@ public class AutoResizeTextView extends TextView {
         _initialized = true;
     }
 
-    @Override
-    public void setText(CharSequence text, BufferType type) {
-        if( _allCaps ) text = text.toString().toUpperCase();
-        super.setText(text, type);
-    }
-    
-    @Override
-    public void  setAllCaps(boolean allCaps){
-        super.setAllCaps(allCaps);
-        _allCaps = allCaps;
-    }
-    
     @Override
     public void setTypeface(final Typeface tf) {
         super.setTypeface(tf);


### PR DESCRIPTION
When property of layout **textAllCaps** was set to true, the string got fit to view before the caps were applied. This fix checks if the property is set, makes the string upper case if true, and then performs the fit.