### PR TITLE
Update sample project configuration to fix deprecation warning

### DIFF
--- a/AutoFitTextViewSample/build.gradle
+++ b/AutoFitTextViewSample/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation project(':AutoFitTextViewLibrary')
-    compile "androidx.core:core-ktx:1.0.1"
+    implementation 'androidx.core:core-ktx:1.0.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }


### PR DESCRIPTION
> WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
Affected Modules: AutoFitTextViewSample