### PR TITLE
Checking for new line character in word wrap

### DIFF
--- a/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.kt
+++ b/AutoFitTextViewLibrary/src/com/lb/auto_fit_textview/AutoResizeTextView.kt
@@ -99,7 +99,7 @@ class AutoResizeTextView @JvmOverloads constructor(context: Context, attrs: Attr
     }
 
     fun isValidWordWrap(before: Char, after: Char): Boolean {
-        return before == ' ' || before == '-'
+        return before == ' ' || before == '-' || before == '\n'
     }
 
     override fun setAllCaps(allCaps: Boolean) {


### PR DESCRIPTION
Allows text to resize correctly with new line character wrap

Signed-off-by: Naqi Syed <naqisyed@gmail.com>